### PR TITLE
v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Mkfile.old
 dkms.conf
 
 .idea
+
+cmake-build-debug
+CMakeLists.txt

--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 ## Introduction
 
-This is `SM Tap Dance` (`sm_td` or `smtd` for short) user library for QMK.
-The main goal of this library is to ultimately fix home row mods (HRM) and tap dance issues in QMK.
-Base functions of this library are:
-- Human-friendly tap+tap vs hold+tap interpretation. Especially useful for `LT()` and `MT()` macros.
-- Better multi-tap and hold (and tap again then) interpretation of the same key
-- Reactive response on multiple taps (and holds)
+This is the `SM Tap Dance` (`sm_td` or `smtd` for short) user library for QMK.
+The main goal of this library is to ultimately fix the Home Row Mods (HRM) and Tap Dance problems in QMK.
+The basic features of this library are:
+- Human-friendly tap+tap vs. hold+tap interpretation. Especially useful for `LT()` and `MT()` macros.
+- Better multi-tap and hold (and then tap again) interpretation of the same key
+- Reactive response to multiple taps (and holds)
 
-This library utilizes natural way of human typing when we have a small overlap between the keys tapping.
-For example, when a person types `hi` fast, he is not releasing `h` before pressing `i`, in other words, finger movements are: `↓h` `↓i` `↑h` `↑i`.
-The main problem with QMK tap dance is that it is not considering this natural way of typing, and it is trying to interpret all the keys pressed and released in the right order.
-So, in the example above, if you put some tap-hold action on `h` key (e.g. `LT(1, KC_H)`), QMK will interpret it as `layer_move(1)` + `tap(KC_I)`.
+This library uses the natural way of human typing when we have a small overlap between key taps.
+For example, when a person types `hi` quickly, he does not release `h` before pressing `i`, in other words, the finger movements are: `↓h` `↓i` `↑h` `↑i`.
+The main problem with QMK tap dance is that it does not consider this natural way of typing and tries to interpret all keys pressed and released in the straight order.
+So in the example above, if you put a tap-hold action on the `h` key (e.g. `LT(1, KC_H)`), QMK will interpret it as `layer_move(1)` + `tap(KC_I)`.
 
-There are many was to fix this issue in QMK, but all of them are not perfect and require some changes in your typing habits.
-Core principle of this library is not trying to change your taping habits. 
-The main idea is to pay attention to the time between key releases (instead of presses) and interpret them in a more human-friendly way.
-So, `↓h` `↓i` `↑h` (tiny pause) `↑i` will be interpreted as `layer_move(1)` + `tap(KC_I)` because as a human we release combo keys almost simultaneously.
-On the other hand, `↓h` `↓i` `↑h` (long pause) `↑i` will be interpreted as `tap(KC_H)` + `tap(KC_I)` because as a human we release sequential keys with a long pause between them.
+There are many other ways to fix this problem in QMK, but all of them are not perfect and require some changes in your typing habits.
+The core principle of this library is respecting human typing habits and not try to change them.
+The main idea is to pay attention to the time between key releases (instead of key presses) and interpret them in a more human-friendly way.
+So, `↓h` `↓i` `↑h` (tiny pause) `↑i` will be interpreted as `layer_move(1)` + `tap(KC_I)` because as humans we release combo keys almost simultaneously.
+On the other hand, `↓h` `↓i` `↑h` (long pause) `↑i` will be interpreted as `tap(KC_H)` + `tap(KC_I)` because as humans we release sequential keys with a long pause in between.
 
-Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive documentation.
+Please see the [wiki](https://github.com/stasmarkin/sm_td/wiki) for extensive documentation.
 
 ## Roadmap
 #### `v0.1.0`
@@ -41,11 +41,11 @@ Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive d
 #### `v0.3.1`
 - optional delay between simultaneous key presses (see SMTD_GLOBAL_SIMULTANEOUS_PRESSES_DELAY_MS in [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags)) 
 #### `v0.4.0` ← we are here
-— simplified installation process (no need to init every key with `SMTD()` macro)
+- simplified installation process (no need to init each key with `SMTD()` macro)
 - added useful `SMTD_MT()`, `SMTD_MTE()`, `SMTD_LT()` macros for easier customization
-- added debugging utilities (see [Debugging guide](https://github.com/stasmarkin/sm_td/wiki/1.3:-Debugging-guide))
-- fixed multiple bugs (especially with sticky modifiers)
-- done some memory optimizations (on storing active states)
+- added debugging utilities (see [Debugging Guide](https://github.com/stasmarkin/sm_td/wiki/1.3:-Debugging-guide))
+- fixed several bugs (especially with sticky modifiers)
+- made some memory optimizations (for storing active states)
 #### `v0.5.0` and further `v0.x`
 - feature requests
 - bug fixes
@@ -62,69 +62,73 @@ Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive d
 See [upgrade instructions](https://github.com/stasmarkin/sm_td/wiki/1.1:-Upgrade-instructions) if already using sm_td library.
 
 ## Installation
-1. Add `DEFERRED_EXEC_ENABLE = yes` to your `rules.mk` file
-2. Add `#define MAX_DEFERRED_EXECUTORS 10` (or add 10 if you are already using this) to your `config.h` file
-3. Clone `sm_td.h` repository into your `keymaps/your_keymap` folder (next to your `keymap.c`)
-4. Add `#include "sm_td.h"` to your `keymap.c` file
+1. Add `DEFERRED_EXEC_ENABLE = yes` to your `rules.mk` file.
+2. Add `#define MAX_DEFERRED_EXECUTORS 10` (or add 10 if you already use it) to your `config.h` file.
+3. Clone the `sm_td.h` repository into your `keymaps/your_keymap` folder (next to your `keymap.c`)
+4. Add `#include "sm_td.h"` to your `keymap.c` file.
 5. Check `!process_smtd` first in your `process_record_user` function like this
-```c
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    if (!process_smtd(keycode, record)) {
-        return false;
-    }
-    // your code here
-}
-```
-6. Add `SMTD_KEYCODES_BEGIN` and `SMTD_KEYCODES_END` into `keymaps`, and put every new custom keycode you want to use with `sm_td` between them.
-   For example, if you want to use `A`, `S`, `D` and `F` for HRM, you will need to create a custom keycodes for them like this:
-```c
-enum custom_keycodes {
-    SMTD_KEYCODES_BEGIN = SAFE_RANGE,
-    CKC_A,
-    CKC_S,
-    CKC_D,
-    CKC_F,
-    SMTD_KEYCODES_END,
-}
-```
-   Please, note that `SAFE_RANGE` is a predefined constant in QMK, and it is used [to define custom keycodes](https://docs.qmk.fm/custom_quantum_functions).
-   Some keyboards may have their own `SAFE_RANGE` constant, so you need to check your firmware for that constant.
-7. Put all your custom keycodes to desired key positions in your `keymaps`.
-8. Create `void on_smtd_action(uint16_t keycode, smtd_action action, uint8_t tap_count)` function that would handle all the actions of custom keycodes you defined in the previous step. 
-   For example, if you want to use `CKC_A`, `CKC_S`, `CKC_D` and `CKC_F` for HRM, your `on_smtd_action()` function will look like this:
-```c
-void on_smtd_action(uint16_t keycode, smtd_action action, uint8_t tap_count) {
-    switch (keycode) {
-        SMTD_MT(CKC_A, KC_A, KC_LEFT_GUI)
-        SMTD_MT(CKC_S, KC_S, KC_LEFT_ALT)
-        SMTD_MT(CKC_D, KC_D, KC_LEFT_CTRL)
-        SMTD_MT(CKC_F, KC_F, KC_LSFT)
-    }
-}
-```
-   See comprehensive documentation in [Customization guide](https://github.com/stasmarkin/sm_td/wiki/2.0:-Customization-guide) with cool [examples](https://github.com/stasmarkin/sm_td/wiki/2.1:-Customization-guide:-Examples)
-9. (optional) Add global configuration parameters in your `config.h` file (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
-10. (optional) Add configuration per key (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
+   ```c
+   bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+       if (!process_smtd(keycode, record)) {
+           return false;
+       }
+       // your code here
+   }
+   ```
+   
+6. Add `SMTD_KEYCODES_BEGIN` and `SMTD_KEYCODES_END` to you custom keycodes, and put each new custom keycode you want to use with `sm_td` between them.
+   For example, if you want to use `A`, `S`, `D` and `F` for HRM, you need to create a custom keycode for them like this
+   ```c
+   enum custom_keycodes {
+       SMTD_KEYCODES_BEGIN = SAFE_RANGE,
+       CKC_A, // reads as C(ustom) + KC_A, but you may give any name here
+       CKC_S,
+       CKC_D,
+       CKC_F,
+       SMTD_KEYCODES_END,
+   }
+   ```
+   Note that `SAFE_RANGE` is a predefined constant in QMK, and is used [to define custom keycodes](https://docs.qmk.fm/custom_quantum_functions).
+   You need to put it on the beginning of your custom keycodes enum.
+   Some keyboards may have their own `SAFE_RANGE` constant, so you need to check your firmware for this constant.
+
+7. Place all your custom keycodes on the desired key positions in your `keymaps`.
+8. Create a `void on_smtd_action(uint16_t keycode, smtd_action action, uint8_t tap_count)` function that would handle all the actions of the custom keycodes you defined in the previous step.
+   For example, if you want to use `CKC_A`, `CKC_S`, `CKC_D` and `CKC_F` for HRM, your `on_smtd_action()` function will look like this
+   ```c
+   void on_smtd_action(uint16_t keycode, smtd_action action, uint8_t tap_count) { }
+       switch (keycode) {
+           SMTD_MT(CKC_A, KC_A, KC_LEFT_GUI)
+           SMTD_MT(CKC_S, KC_S, KC_LEFT_ALT)
+           SMTD_MT(CKC_D, KC_D, KC_LEFT_CTRL)
+           SMTD_MT(CKC_F, KC_F, KC_LSFT)
+       }
+   }
+   ```
+   See extensive documentation in the [Customization Guide](https://github.com/stasmarkin/sm_td/wiki/2.0:-Customization-guide) with cool [Examples](https://github.com/stasmarkin/sm_td/wiki/2.1:-Customization-guide:-Examples)
+
+9. (optional) Add global configuration parameters to your `config.h` file (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags)).
+10. (optional) Add per-key configuration (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
 
 
 ## What is `on_smtd_action()` function?
 
-Once you hit a key assigned to sm_td, all the state machines stack starts to work.
-Other keys you press after running sm_td state machine will be also processed by sm_td state machine.
-That state machine could decide to postpone processing of the key you pressed, so it will be considered as a tap or hold later. 
-You don't need to worry about that, sm_td will process all the keys you pressed in the right order and a very predictable way.
-You also don't worry about that state machines stack implementation, but you need to know what output you will get from sm_td state machine.
-Once you press keys assigned to sm_td, it will be calling `on_smtd_action()` function with the following arguments:
+As soon as you press a key assigned between `SMTD_KEYCODES_BEGIN` and `SMTD_KEYCODES_END`, all state machines in the stack start working.
+Other keys you press after the sm_td state machine has run will also be processed by the sm_td state machine.
+This state machine might decide to postpone the processing of the key you pressed, so that it will be considered a tap or hold later.
+You don't have to worry about this, sm_td will process all keys you press in the correct order and in a very predictable way.
+You also don't need to worry about the implementation of the state machine stack, but you do need to know what output you will get from sm_td's state machine.
+As soon as you press keys assigned to sm_td, it will call the `on_smtd_action()` function with the following arguments
 - uint16_t keycode - keycode of the key you pressed
-- smtd_action action - result interpreted action (`SMTD_ACTION_TOUCH`, `SMTD_ACTION_TAP`, `SMTD_ACTION_HOLD`, `SMTD_ACTION_RELEASE`). tap, hold and release are self-explanatory. Touch action fired on key press (without knowing if it is going to be a tap or hold).
-- uint8_t tap_count - number of sequential taps before current action. (will reset after hold, pause or any other key press)
+- smtd_action action - result interpreted action (`SMTD_ACTION_TOUCH`, `SMTD_ACTION_TAP`, `SMTD_ACTION_HOLD`, `SMTD_ACTION_RELEASE`). tap, hold and release are self-explanatory. Touch action fired on key press (without knowing if it is a tap or hold).
+- uint8_t tap_count - number of consecutive taps before the current action. (will be reset after hold, pause or any other keypress)
 
-There are only two execution flows for `on_smtd_action` function:
-- `SMTD_ACTION_TOUCH` → `SMTD_ACTION_TAP` 
-- `SMTD_ACTION_TOUCH` → `SMTD_ACTION_HOLD` → `SMTD_ACTION_RELEASE`
+There are only two execution flows for the `on_smtd_action' function:
+- `SMTD_ACTION_TOUCH` → `SMTD_ACTION_TAP`.
+- `SMTD_ACTION_TOUCH` → `SMTD_ACTION_HOLD` → `SMTD_ACTION_RELEASE`.
 
-For better understanding of the execution flow, please check the following example.
-Let's say you want to tap, tap, hold, and tap again some custom key `CKC`. Here is your finger movements:
+For a better understanding of the execution flow, please check the following example.
+Let's say you want to tap, tap, hold and tap again a custom key `CKC`. Here are your finger movements:
 
 - `↓CKC` 50ms `↑CKC` (first tap finished) 50ms 
 - `↓CKC` 50ms `↑CKC` (second tap finished) 50ms 
@@ -133,13 +137,13 @@ Let's say you want to tap, tap, hold, and tap again some custom key `CKC`. Here 
 
 For this example, you will get the following `on_smtd_action()` calls:
 - `on_smtd_action(CKC, SMTD_ACTION_TOUCH, 0)` right after pressing `↓CKC`
-- `on_smtd_action(CKC, SMTD_ACTION_TAP, 0)` right after releasing `↑CKC` (first tap)
+- `on_smtd_action(CKC, SMTD_ACTION_TAP, 0)` right after releasing `↑CKC` (first tap finished)
 - `on_smtd_action(CKC, SMTD_ACTION_TOUCH, 1)` right after pressing `↓CKC` second time
-- `on_smtd_action(CKC, SMTD_ACTION_TAP, 1)` right after releasing `↑CKC` second time (second tap)
+- `on_smtd_action(CKC, SMTD_ACTION_TAP, 1)` right after releasing `↑CKC` second time (second tap finished)
 - `on_smtd_action(CKC, SMTD_ACTION_TOUCH, 2)` right after pressing `↓CKC` third time
 - `on_smtd_action(CKC, SMTD_ACTION_HOLD, 2)` after holding `CKC` long enough
 - `on_smtd_action(CKC, SMTD_ACTION_RELEASE, 2)` right after releasing `↑CKC` (hold)
 - `on_smtd_action(CKC, SMTD_ACTION_TOUCH, 0)` right after pressing `↓CKC` fourth time
-- `on_smtd_action(CKC, SMTD_ACTION_TAP, 0)` right after releasing `↑CKC` (third tap)
+- `on_smtd_action(CKC, SMTD_ACTION_TAP, 0)` right after releasing `↑CKC` (third tap finished)
 
-For deeper understanding of the execution flow, please check [state machine description](https://github.com/stasmarkin/sm_td/wiki/3.0:-Deep-explanation:-Stages) and further [one key explanation](https://github.com/stasmarkin/sm_td/wiki/3.1:-Deep-explanation:-One-key-stages), [two keys explanation](https://github.com/stasmarkin/sm_td/wiki/3.2:-Deep-explanation:-Two-keys-stages) and [state machine stack](https://github.com/stasmarkin/sm_td/wiki/3.3:-Deep-explanation:-Three-keys-and-states-stack).
+If you need, there is a deeper documentation on execution flow, please see [state machine description](https://github.com/stasmarkin/sm_td/wiki/3.0:-Deep-explanation:-Stages) and further [one key explanation](https://github.com/stasmarkin/sm_td/wiki/3.1:-Deep-explanation:-One-key-stages), [two key explanation](https://github.com/stasmarkin/sm_td/wiki/3.2:-Deep-explanation:-Two-keys-stages) and [state machine stack](https://github.com/stasmarkin/sm_td/wiki/3.3:-Deep-explanation:-Three-keys-and-states-stack).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive d
 #### `v0.4.0` ← we are here
 — Simplified installation process 
 - fixme: update installation instructions and add migration guide for SMTD_KEYCODES_BEGIN and SMTD_KEYCODES_END
+- fixme: multiple bug fixes
+- fixme: debugging tools
 #### `v0.5.0` and further `v0.x`
 - feature requests
 - bug fixes

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive d
 - reduce args number for get_smtd_timeout_default and smtd_feature_enabled_default functions (see Upgrade instructions)
 - better stage naming 
 - comprehensive documentation
-#### `v0.3.1` ← we are here
+#### `v0.3.1`
 - optional delay between simultaneous key presses (see SMTD_GLOBAL_SIMULTANEOUS_PRESSES_DELAY_MS in [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags)) 
-#### `v0.4.0` and further `v0.x`
+#### `v0.4.0` ← we are here
+— Simplified installation process 
+- fixme: update installation instructions and add migration guide for SMTD_KEYCODES_BEGIN and SMTD_KEYCODES_END
+#### `v0.5.0` and further `v0.x`
 - feature requests
 - bug fixes
 #### `v1.0.0`
@@ -69,23 +72,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     // your code here
 }
 ```
-6. Add some custom keycodes to your `keymaps`, so sm_td library can use them without conflicts
-7. Declare variable `smtd_states` your custom keycodes and variable `smtd_states_size` for sm_td library like this:
-```c
-smtd_state smtd_states[] = {
-    SMTD(CUSTOM_KEYCODE_1),
-    SMTD(CUSTOM_KEYCODE_2),
-    // put all your custom keycodes here
-}
-
-// this is the size of your custom keycodes array, it is used for internal purposes. Do not delete this
-size_t smtd_states_size = sizeof(smtd_states) / sizeof(smtd_states[0]);
-```
-8. Describe your custom keycodes in `on_smtd_action` function. 
+6. Add some custom keycodes to your `keymaps`, so sm_td library can use them without conflicts. fixme SMTD_KEYCODES_END
+7. Describe your custom keycodes in `on_smtd_action` function. 
    See comprehensive documentation in [Customization guide](https://github.com/stasmarkin/sm_td/wiki/2.0:-Customization-guide) with cool [examples](https://github.com/stasmarkin/sm_td/wiki/2.1:-Customization-guide:-Examples)
 
-9. (optional) Add global configuration parameters in your `config.h` file (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
-10. (optional) Add configuration per key (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
+8. (optional) Add global configuration parameters in your `config.h` file (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
+9. (optional) Add configuration per key (see [timeouts](https://github.com/stasmarkin/sm_td/wiki/2.2:-Customization-guide:-Timeouts-per-key) and [feature flags](https://github.com/stasmarkin/sm_td/wiki/2.3:-Customization-guide:-Feature-flags))
 
 
 ## Basic usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # sm_td
-This is `SM Tap Dance` user library for QMK
-
 
 ## Introduction
+
+This is `SM Tap Dance` user library for QMK.
+The main goal of this library is to ultimately fix home row mods (HRM) and tap dance issues in QMK.
+
 This is a user library for QMK with custom implementations of Tap Dance functions with reliable tap+tap vs tap+hold decision mechanism. 
 It offers smooth and fast tap dance multi-tap and hold interpretation with a very predictable behavior.
 Base functions are:
@@ -45,6 +47,8 @@ Please, see [wiki](https://github.com/stasmarkin/sm_td/wiki) for comprehensive d
 - fixme: update installation instructions and add migration guide for SMTD_KEYCODES_BEGIN and SMTD_KEYCODES_END
 - fixme: multiple bug fixes
 - fixme: debugging tools
+- fixme: SMTD_MT, SMTD_MTE, SMTD_LT macros
+- memory optimizations (on storing active states)
 #### `v0.5.0` and further `v0.x`
 - feature requests
 - bug fixes

--- a/sm_td.h
+++ b/sm_td.h
@@ -171,7 +171,7 @@ typedef struct {
 
 smtd_state *smtd_active_states[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 uint8_t smtd_active_states_next_idx = 0;
-bool smtd_not_init = false;
+bool smtd_not_init = true;
 static size_t smtd_states_size = SMTD_KEYCODES_END - SMTD_KEYCODES_BEGIN - 1;
 static smtd_state smtd_states[SMTD_KEYCODES_END - SMTD_KEYCODES_BEGIN - 1];
 
@@ -441,7 +441,7 @@ bool process_smtd(uint16_t keycode, keyrecord_t *record) {
             smtd_states[i].timeout = INVALID_DEFERRED_TOKEN;
             smtd_states[i].sequence_len = 0;
         }
-        smtd_not_init = true;
+        smtd_not_init = false;
     }
 
     for (uint8_t i = 0; i < smtd_active_states_next_idx; i++) {

--- a/sm_td.h
+++ b/sm_td.h
@@ -289,30 +289,30 @@ static size_t smtd_states_size = SMTD_KEYCODES_END - SMTD_KEYCODES_BEGIN - 1;
 static smtd_state smtd_states[SMTD_KEYCODES_END - SMTD_KEYCODES_BEGIN - 1];
 
 
-#define DO_ACTION_TAP(state)                                                                                                  \
-    uint8_t current_mods = get_mods();                                                                                        \
-    if (                                                                                                                      \
-            smtd_feature_enabled_or_default(state->macro_keycode, SMTD_FEATURE_MODS_RECALL)                                   \
-            && state->modes_before_touch != current_mods                                                                             \
-            ) { \
-        set_mods(state->modes_before_touch);                                                                                            \
-        send_keyboard_report();                                                                                               \
-        \
-        SMTD_SIMULTANEOUS_PRESSES_DELAY                                                                                       \
-        CONSOLE_LOG(SMTD_ACTION_TAP, state) \
-        on_smtd_action(state->macro_keycode, SMTD_ACTION_TAP, state->sequence_len);                                           \
-        uint8_t mods_diff = get_mods() ^ state->modes_before_touch; \
-                                                                                                                              \
-        SMTD_SIMULTANEOUS_PRESSES_DELAY                                                                                      \
-        set_mods(current_mods ^ mods_diff);        \
-        del_mods(state->modes_with_touch); \
-        send_keyboard_report();                                                                                               \
-                                                                                                                              \
-        state->modes_before_touch = 0; /* fixme this is a quick fix */ \
-        state->modes_with_touch = 0; /* fixme this is a quick fix */ \
-    } else {\
-        CONSOLE_LOG(SMTD_ACTION_TAP, state) \
-        on_smtd_action(state->macro_keycode, SMTD_ACTION_TAP, state->sequence_len);                                               \
+#define DO_ACTION_TAP(state)                                                                 \
+    uint8_t current_mods = get_mods();                                                       \
+    if (                                                                                     \
+            smtd_feature_enabled_or_default(state->macro_keycode, SMTD_FEATURE_MODS_RECALL)  \
+            && state->modes_before_touch != current_mods                                     \
+            ) {                                                                              \
+        set_mods(state->modes_before_touch);                                                 \
+        send_keyboard_report();                                                              \
+                                                                                             \
+        SMTD_SIMULTANEOUS_PRESSES_DELAY                                                      \
+        CONSOLE_LOG(SMTD_ACTION_TAP, state)                                                  \
+        on_smtd_action(state->macro_keycode, SMTD_ACTION_TAP, state->sequence_len);          \
+        uint8_t mods_diff = get_mods() ^ state->modes_before_touch;                          \
+                                                                                             \
+        SMTD_SIMULTANEOUS_PRESSES_DELAY                                                      \
+        set_mods(current_mods ^ mods_diff);                                                  \
+        del_mods(state->modes_with_touch);                                                   \
+        send_keyboard_report();                                                              \
+                                                                                             \
+        state->modes_before_touch = 0;                                                       \
+        state->modes_with_touch = 0;                                                         \
+    } else {                                                                                 \
+        CONSOLE_LOG(SMTD_ACTION_TAP, state)                                                  \
+        on_smtd_action(state->macro_keycode, SMTD_ACTION_TAP, state->sequence_len);          \
     }
 
 void smtd_press_following_key(smtd_state *state, bool release) {
@@ -786,7 +786,7 @@ bool process_smtd(uint16_t keycode, keyrecord_t *record) {
     case macro_key: {                                         \
         switch (action) {                                     \
             case SMTD_ACTION_TOUCH:                           \
-                register_mods(MOD_BIT(mod));     \
+                register_mods(MOD_BIT(mod));                  \
                 break;                                        \
             case SMTD_ACTION_TAP:                             \
                 unregister_mods(MOD_BIT(mod));                \

--- a/sm_td.h
+++ b/sm_td.h
@@ -308,7 +308,6 @@ static smtd_state smtd_states[SMTD_KEYCODES_END - SMTD_KEYCODES_BEGIN - 1];
         del_mods(state->modes_with_touch); \
         send_keyboard_report();                                                                                               \
                                                                                                                               \
-        /* fixme сначала заходить в стейт, а потом делать экшон */ \
         state->modes_before_touch = 0; /* fixme this is a quick fix */ \
         state->modes_with_touch = 0; /* fixme this is a quick fix */ \
     } else {\
@@ -351,7 +350,6 @@ uint32_t timeout_reset_seq(uint32_t trigger_time, void *cb_arg) {
 uint32_t timeout_touch(uint32_t trigger_time, void *cb_arg) {
     smtd_state *state = (smtd_state *) cb_arg;
     smtd_next_stage(state, SMTD_STAGE_HOLD);
-
     return 0;
 }
 
@@ -363,7 +361,6 @@ uint32_t timeout_sequence(uint32_t trigger_time, void *cb_arg) {
     }
 
     smtd_next_stage(state, SMTD_STAGE_NONE);
-
     return 0;
 }
 
@@ -373,7 +370,6 @@ uint32_t timeout_following_touch(uint32_t trigger_time, void *cb_arg) {
 
     SMTD_SIMULTANEOUS_PRESSES_DELAY
     smtd_press_following_key(state, false);
-
     return 0;
 }
 
@@ -386,7 +382,6 @@ uint32_t timeout_release(uint32_t trigger_time, void *cb_arg) {
     smtd_press_following_key(state, false);
 
     smtd_next_stage(state, SMTD_STAGE_NONE);
-
     return 0;
 }
 
@@ -484,11 +479,11 @@ bool process_smtd_state(uint16_t keycode, keyrecord_t *record, smtd_state *state
                 return false;
             }
             if (keycode != state->macro_keycode && record->event.pressed) {
+                smtd_next_stage(state, SMTD_STAGE_FOLLOWING_TOUCH);
                 state->following_key = record->event.key;
                 #ifdef SMTD_DEBUG_ENABLED
                 state->following_keycode = keycode;
                 #endif
-                smtd_next_stage(state, SMTD_STAGE_FOLLOWING_TOUCH);
                 return false;
             }
             return true;
@@ -588,12 +583,12 @@ bool process_smtd_state(uint16_t keycode, keyrecord_t *record, smtd_state *state
                 SMTD_SIMULTANEOUS_PRESSES_DELAY
                 smtd_press_following_key(state, false);
 
+                //todo need to go to NONE stage and from NONE jump to TOUCH stage
                 SMTD_SIMULTANEOUS_PRESSES_DELAY
                 smtd_next_stage(state, SMTD_STAGE_TOUCH);
 
                 state->sequence_len = 0;
 
-                //fixme тут нужно выходить в none, а потом опять запускаться
                 return false;
             }
             if (
@@ -618,7 +613,7 @@ bool process_smtd_state(uint16_t keycode, keyrecord_t *record, smtd_state *state
 
                 smtd_next_stage(state, SMTD_STAGE_NONE);
 
-                return false; //fixme-sm double check this. It was true, but I don't know why
+                return false;
             }
             if (
                     keycode != state->macro_keycode

--- a/sm_td.h
+++ b/sm_td.h
@@ -30,7 +30,6 @@
 #include "timer.h"
 #endif
 
-
 /* ************************************* *
  *         GLOBAL CONFIGURATION          *
  * ************************************* */
@@ -187,7 +186,6 @@ char *smtd_action_to_string(smtd_action action) {
 #endif
 
 void on_smtd_action(uint16_t keycode, smtd_action action, uint8_t sequence_len);
-
 
 /* ************************************* *
  *       USER STATES DEFINITIONS         *
@@ -726,7 +724,6 @@ bool process_smtd(uint16_t keycode, keyrecord_t *record) {
     #endif
     return true;
 }
-
 
 /* ************************************* *
  *         CUSTOMIZATION MACROS          *


### PR DESCRIPTION
- simplified installation process (no need to init each key with `SMTD()` macro)
- added useful `SMTD_MT()`, `SMTD_MTE()`, `SMTD_LT()` macros for easier customization
- added debugging utilities
- fixed several bugs (especially with sticky modifiers)
- made some memory optimizations (for storing active states)