### PR TITLE
fix: finalize stacked held modifiers (S_HOLD_RELEASE timeout)

### DIFF
--- a/sm_td/sm_td.c
+++ b/sm_td/sm_td.c
@@ -617,6 +617,10 @@ void smtd_apply_stage(smtd_state *state, smtd_stage next_stage) {
 
         case SMTD_STAGE_HOLD_RELEASE:
             state->released_time = timer_read32();
+            state->release_term = smtd_compute_release_term(state);
+            state->timeout = defer_exec(state->release_term, timeout_hold_release, state);
+            SMTD_DEBUG("%s timeout_hold_release in %lums", smtd_state_to_str(state),
+                       state->release_term);
             break;
     }
 


### PR DESCRIPTION
## Проблема

Постоянно падали 4 ассерта в unit-тестах `test_stirred_long_mod_smtd_press2_fixed` (наборы `caps_word_enable` и `complex_layout`).

Сценарий: два мода зажаты стопкой (`CTRL` → стадия `S_HOLD`, сверху держится `MT1`), затем нижний `CTRL` отпускают, пока `MT1` ещё активен. В `SMTD_STAGE_HOLD` отпускание не-верхнего состояния переводит его в `SMTD_STAGE_HOLD_RELEASE`, но `smtd_apply_stage` для этой стадии **не планировал** `defer_exec` — состояние зависало навсегда, а его модификатор оставался зарегистрированным.

Это не только ломало тесты, но и реальный баг прошивки: нижний из двух зажатых модификаторов застревал в нажатом состоянии.

## Причина

Функция `timeout_hold_release` была **определена, но нигде не использовалась** — потерянный кусок исходного дизайна. По замыслу `SMTD_STAGE_HOLD_RELEASE` должен планировать её, чтобы зависший зажатый мод финализировался по release-терму.

## Фикс

В `smtd_apply_stage`, ветка `SMTD_STAGE_HOLD_RELEASE`, добавлено планирование `timeout_hold_release` с release-термом — по аналогии с уже существующим `SMTD_STAGE_TOUCH_RELEASE`.

## Тесты

- Python unit: 117 тестов — OK
- QMK 0.33.5 integration (8 сьют): 51 тест — все PASSED

Итого 168 тестов зелёные, exit code 0.